### PR TITLE
Fixed a flaky test

### DIFF
--- a/src/test/java/com/in/nan/api/EmployeeRestControllerMockMVCTest.java
+++ b/src/test/java/com/in/nan/api/EmployeeRestControllerMockMVCTest.java
@@ -38,6 +38,6 @@ public class EmployeeRestControllerMockMVCTest {
         employees.add(employee);
         Mockito.when(employeeService.retrieveEmployees()).thenReturn(employees);
         mockMvc.perform(MockMvcRequestBuilders.get("/api/employees/")).andDo(print()).andExpect(status().isOk())
-                .andExpect(content().string(containsString("[{\"id\":null,\"name\":\"Noushath\",\"salary\":1000,\"department\":\"IT\",\"profilePicPath\":null}]")));
+                .andExpect(content().json("[{\"id\":null,\"name\":\"Noushath\",\"salary\":1000,\"department\":\"IT\",\"profilePicPath\":null}]"));
     }
 }


### PR DESCRIPTION
### Identified a Flaky Test in com.in.nan.api.EmployeeRestControllerMockMVCTest.java

### Failing Test:
 **Class: com.in.nan.api.EmployeeRestControllerMockMVCTest.**
 **Test**
- > [com.in.nan.api.EmployeeRestControllerMockMVCTest#testEmployeeGet](https://github.com/NoushathMoidu2020/Spring-Boot-Starter-Kit/blob/c474aca9621c09af41cbba962f3a7d6f1ab593fd/src/test/java/com/in/nan/api/EmployeeRestControllerMockMVCTest.java#L32) 

### Reason for the Test Failure:

In the testEmployeeGet() function, we check if we get the expected JSON object from the "/api/employees/" endpoint. But we check the actual result and expected result as strings and when comparing JSON strings, since JSON is inherently unordered (the order of keys in JSON objects is not guaranteed), it's not reliable to compare JSON strings directly if the order of the keys may vary. Instead, we should parse the JSON strings into objects and compare the objects semantically.
https://github.com/NoushathMoidu2020/Spring-Boot-Starter-Kit/blob/c474aca9621c09af41cbba962f3a7d6f1ab593fd/src/test/java/com/in/nan/api/EmployeeRestControllerMockMVCTest.java#L41

### Solution Implemented:

Instead of doing a string check, we can check the actual result and expected result as JSON itself. By doing a JSON check, we need not worry about the order of the parameters. 

### Steps to Reproduce:
I utilized the open-source tool [NonDex](https://github.com/TestingResearchIllinois/NonDex) to detect this assumption by altering the order of returned exception types.

 **To replicate:**
> Clone the Repository:
> ```
> git clone https://github.com/NoushathMoidu2020/Spring-Boot-Starter-Kit.git
> ```

**Integrate NonDex:**
> Add the following snippet to the top of the build.gradle file:
> ```
> plugins {
>     id 'edu.illinois.nondex' version '2.1.1-1'
> }
> ```
> **Add to the end of the build.gradle file:**
> ```
> apply plugin: 'edu.illinois.nondex'
> ```
**Execute Test with Gradle:**
> ```
> ./gradlew --info test --tests com.in.nan.api.EmployeeRestControllerMockMVCTest#testEmployeeGet
> ```
**Run NonDex:**
> ```
> ./gradlew --info nondexTest --tests=com.in.nan.api.EmployeeRestControllerMockMVCTest#testEmployeeGet --nondexRuns=3
> ```